### PR TITLE
Restart simulation to reset the history

### DIFF
--- a/node/src/main/scala/node/api/web/PublicApiJson.scala
+++ b/node/src/main/scala/node/api/web/PublicApiJson.scala
@@ -12,6 +12,7 @@ final case class PublicApiJson[F[_]: Concurrent, B, D](
   deployF: String => F[D],
   balanceF: (String, String) => F[Long],
   latestF: F[Set[String]],
+  statusF: F[String],
 )(implicit
   blockEncoder: EntityEncoder[F, B],
   deployEncoder: EntityEncoder[F, D],
@@ -26,6 +27,7 @@ final case class PublicApiJson[F[_]: Concurrent, B, D](
       deploy[D].implementedByEffect(deployF),
       balance[Long].implementedByEffect(balanceF.tupled),
       latest[Set[String]].implementedByEffect(_ => latestF),
+      status[String].implementedByEffect(_ => statusF),
     ),
   )
 }

--- a/node/src/main/scala/node/api/web/endpoints/PublicApiEndpoints.scala
+++ b/node/src/main/scala/node/api/web/endpoints/PublicApiEndpoints.scala
@@ -34,4 +34,10 @@ trait PublicApiEndpoints extends algebra.Endpoints with algebra.JsonEntitiesFrom
     ok(r),
     docs = EndpointDocs().withDescription("Balance of a wallet at the state specified".some),
   )
+
+  def status[A](implicit r: ResponseEntity[A]): Endpoint[Unit, A] = endpoint(
+    get(path / "status"),
+    ok(r),
+    docs = EndpointDocs().withDescription("Status".some),
+  )
 }

--- a/sim/src/main/scala/sim/NetworkSim.scala
+++ b/sim/src/main/scala/sim/NetworkSim.scala
@@ -312,6 +312,7 @@ object NetworkSim extends IOApp {
                     .flatMap(_.liftTo[F])
                 },
                 latestBlocks,
+                getData.map(_.show),
               ).routes
 
               val allRoutes = RouterFix(s"/${sdk.api.RootPath.mkString("/")}" -> routes)
@@ -387,6 +388,9 @@ object NetworkSim extends IOApp {
     Available API endpoints:
       - latest blocks node observes from each peer
       http://127.0.0.1:8080/api/v1/latest
+
+      - status
+      http://127.0.0.1:8080/api/v1/status
 
       - block given id
       http://127.0.0.1:8080/api/v1/block/<block_id>


### PR DESCRIPTION
## Overview

Small change to add possibility to restart simulation upon KV store backing history reaches some size. 

Since no garbage collect for on chain state yet, simulation cannot run forever and the easiest way for now to keep simulation running is to restart from genesis.

Another commit is to expose diagnostics string present in the console animation through web API.

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
