### PR TITLE
Add DB table for store and load settings & unit test

### DIFF
--- a/db/src/main/scala/slick/SlickQuery.scala
+++ b/db/src/main/scala/slick/SlickQuery.scala
@@ -2,6 +2,7 @@ package slick
 
 import sdk.api.data.Validator
 import slick.jdbc.JdbcProfile
+import slick.sql.SqlAction
 
 final case class SlickQuery()(implicit val profile: JdbcProfile) {
   import profile.api.*
@@ -16,4 +17,10 @@ final case class SlickQuery()(implicit val profile: JdbcProfile) {
 
   def getValidatorByPublicKey(publicKey: Array[Byte]) =
     validators.filter(_.publicKey === publicKey).result.headOption
+
+  def storeValue(key: String, value: String): SqlAction[Int, NoStream, Effect.Write] =
+    config.insertOrUpdate((key, value))
+
+  def loadValue(key: String): SqlAction[Option[String], NoStream, Effect.Read] =
+    config.filter(_.name === key).map(_.value).result.headOption
 }

--- a/db/src/main/scala/slick/migrations/Baseline.scala
+++ b/db/src/main/scala/slick/migrations/Baseline.scala
@@ -12,6 +12,9 @@ object Baseline {
     val bondTable = TableMigration(slick.bonds).create
       .addColumns(_.id, _.validatorId, _.stake)
 
-    validatorTable & bondTable
+    val configTable = TableMigration(slick.config).create
+      .addColumns(_.name, _.value)
+
+    validatorTable & bondTable & configTable
   }
 }

--- a/db/src/main/scala/slick/package.scala
+++ b/db/src/main/scala/slick/package.scala
@@ -1,9 +1,10 @@
 import slick.lifted.TableQuery
-import slick.tables.{TableBonds, TableValidators}
+import slick.tables.{TableBonds, TableConfig, TableValidators}
 
 package object slick {
 
   // all queries
   val bonds      = TableQuery[TableBonds]
   val validators = TableQuery[TableValidators]
+  val config     = TableQuery[TableConfig]
 }

--- a/db/src/main/scala/slick/tables/TableConfig.scala
+++ b/db/src/main/scala/slick/tables/TableConfig.scala
@@ -1,0 +1,11 @@
+package slick.tables
+
+import slick.jdbc.PostgresProfile.api.*
+import slick.lifted.ProvenShape
+
+class TableConfig(tag: Tag) extends Table[(String, String)](tag, "Config") {
+  def name: Rep[String]  = column[String]("name", O.PrimaryKey)
+  def value: Rep[String] = column[String]("value")
+
+  def * : ProvenShape[(String, String)] = (name, value)
+}

--- a/db/src/test/scala/db/slick/SlickSpec.scala
+++ b/db/src/test/scala/db/slick/SlickSpec.scala
@@ -1,15 +1,20 @@
 package db.slick
 
 import cats.data.OptionT
-import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import cats.effect.{Async, IO}
+import cats.syntax.all.*
 import org.scalacheck.ScalacheckShapeless.*
+import org.scalatest.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import sdk.api.data.*
 import sdk.db.*
 import slick.api.*
+import slick.jdbc.JdbcProfile
+import slick.syntax.all.*
+import slick.{SlickDb, SlickQuery}
 
 class SlickSpec extends AsyncFlatSpec with Matchers with ScalaCheckPropertyChecks {
 
@@ -30,6 +35,25 @@ class SlickSpec extends AsyncFlatSpec with Matchers with ScalaCheckPropertyCheck
       EmbeddedH2SlickDb[IO]
         .map(implicit x => new ValidatorDbApiImplSlick[IO])
         .use(test)
+        .unsafeRunSync()
+    }
+  }
+
+  "Stored and loaded name-value pairs" should "be the same" in {
+    forAll { (name: String, value: String) =>
+      def test[F[_]: Async](storeF: => F[Int], loadF: => F[Option[String]]): F[Assertion] = for {
+        _         <- storeF
+        extracted <- OptionT(loadF).getOrRaise(new RuntimeException("Failed to get value by name"))
+      } yield extracted shouldBe value
+
+      EmbeddedH2SlickDb[IO]
+        .use { implicit slickDb =>
+          implicit val profile: JdbcProfile = SlickDb[IO].profile
+          implicit val async                = Async[IO]
+          val queries: SlickQuery           = SlickQuery()
+          import queries.*
+          test[IO](storeValue(name, value).run, loadValue(name).run)
+        }
         .unsafeRunSync()
     }
   }


### PR DESCRIPTION
## Overview

Data is stored in the `Config` table as name-value pairs and retrieved by parameter name.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
