### PR TITLE
Make KamonContextStore constructor return suspended value

### DIFF
--- a/diag/src/main/scala/diagnostics/KamonContextStore.scala
+++ b/diag/src/main/scala/diagnostics/KamonContextStore.scala
@@ -21,10 +21,7 @@ trait KamonContextStore[F[_]] {
 object KamonContextStore {
   def apply[F[_]](implicit ev: KamonContextStore[F]): KamonContextStore[F] = ev
 
-  def forCatsEffectIOLocal = {
-    import cats.effect.unsafe.implicits.global
-    val ioLocalKamonContext = IOLocal(Kamon.currentContext()).unsafeRunSync()
-
+  def forCatsEffectIOLocal: IO[KamonContextStore[IO]] = IOLocal(Kamon.currentContext()).map { ioLocalKamonContext =>
     new KamonContextStore[IO] {
       override def get: IO[Context]             = ioLocalKamonContext.get
       override def set(span: Context): IO[Unit] = ioLocalKamonContext.set(span)


### PR DESCRIPTION
## Overview

Remove unsafeRunSync that uses global execution context, use execution context provided on app initialisation instead.

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
