### PR TITLE
PoC of the new normalizer

### DIFF
--- a/legacy/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PMatchNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PMatchNormalizer.scala
@@ -46,6 +46,9 @@ object PMatchNormalizer {
                                                  caseBody,
                                                  ProcVisitInputs(NilN, caseEnv, acc._2),
                                                )
+
+                             // TODO: is this assert always true?? and we can get rid of `countNoWildcards`
+                             // _ = assert(boundCount == patternResult.freeMap.levelBindings.size)
                            } yield (
                              MatchCaseN(
                                patternResult.par,

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
@@ -2,7 +2,6 @@ package coop.rchain.rholang.normalizer2
 
 import cats.effect.Sync
 import cats.syntax.all.*
-import coop.rchain.rholang.interpreter.compiler.VarSort
 import coop.rchain.rholang.interpreter.errors.UnrecognizedNormalizerError
 import coop.rchain.rholang.normalizer2.env.{BoundVarWriter, FreeVarReader, FreeVarWriter}
 import io.rhonix.rholang.ast.rholang.Absyn.{Case, CaseImpl, PMatch, Proc}
@@ -11,7 +10,7 @@ import io.rhonix.rholang.{MatchCaseN, MatchN}
 import scala.jdk.CollectionConverters.*
 
 object MatchNormalizer {
-  def normalizerMatch[F[_]: Sync: NormalizerRec, T <: VarSort: BoundVarWriter: FreeVarReader: FreeVarWriter](
+  def normalizerMatch[F[_]: Sync: NormalizerRec, T: BoundVarWriter: FreeVarReader: FreeVarWriter](
     p: PMatch,
   ): F[MatchN] = {
     def liftCase(c: Case): F[(Proc, Proc)] = c match {

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
@@ -41,11 +41,13 @@ object MatchNormalizer {
 
                          (patternResult, freeVars, freeVarCount) = patternTuple
 
-                         // Bound free variables in the current scope
-                         _ = BoundVarWriter[T].absorbFree(freeVars)
+                         caseBodyResult <- BoundVarWriter[T].withCopyBoundVarScope { () =>
+                                             // Bound free variables in the current scope
+                                             BoundVarWriter[T].absorbFree(freeVars)
 
-                         // Normalize body in the current bound and free variables scope
-                         caseBodyResult <- NormalizerRec[F].normalize(caseBody)
+                                             // Normalize body in the current bound and free variables scope
+                                             NormalizerRec[F].normalize(caseBody)
+                                           }
                        } yield MatchCaseN(patternResult, caseBodyResult, freeVarCount) +: acc
                      }
     } yield MatchN(targetResult, casesResult.reverse)

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
@@ -31,15 +31,14 @@ object MatchNormalizer {
                          patternTuple <- BoundVarWriter[T].withNewBoundVarScope(() =>
                                            FreeVarWriter[T].withNewFreeVarScope(() =>
                                              for {
-                                               pattern     <- NormalizerRec[F].normalize(pattern)
+                                               pattern <- NormalizerRec[F].normalize(pattern)
                                                // Get free variables from the pattern
-                                               freeVars     = FreeVarReader[T].getFreeVars
-                                               freeVarCount = FreeVarReader[T].countNoWildcards
-                                             } yield (pattern, freeVars, freeVarCount),
+                                               freeVars = FreeVarReader[T].getFreeVars
+                                             } yield (pattern, freeVars),
                                            ),
                                          )
 
-                         (patternResult, freeVars, freeVarCount) = patternTuple
+                         (patternResult, freeVars) = patternTuple
 
                          caseBodyResult <- BoundVarWriter[T].withCopyBoundVarScope { () =>
                                              // Bound free variables in the current scope
@@ -48,7 +47,7 @@ object MatchNormalizer {
                                              // Normalize body in the current bound and free variables scope
                                              NormalizerRec[F].normalize(caseBody)
                                            }
-                       } yield MatchCaseN(patternResult, caseBodyResult, freeVarCount) +: acc
+                       } yield MatchCaseN(patternResult, caseBodyResult, freeVars.length) +: acc
                      }
     } yield MatchN(targetResult, casesResult.reverse)
   }

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
@@ -19,8 +19,9 @@ object MatchNormalizer {
     }
 
     for {
-      targetResult <- BoundVarWriter[T].withCopyBoundVarScope(() => NormalizerRec[F].normalize(p.proc_))
-      cases        <- p.listcase_.asScala.toList.traverse(liftCase)
+      targetResult <- NormalizerRec[F].normalize(p.proc_)
+
+      cases <- p.listcase_.asScala.toList.traverse(liftCase)
 
       initAcc      = Vector[MatchCaseN]()
       casesResult <- cases.foldM(initAcc) { case (acc, (pattern, caseBody)) =>

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala
@@ -1,0 +1,53 @@
+package coop.rchain.rholang.normalizer2
+
+import cats.effect.Sync
+import cats.syntax.all.*
+import coop.rchain.rholang.interpreter.compiler.VarSort
+import coop.rchain.rholang.interpreter.errors.UnrecognizedNormalizerError
+import coop.rchain.rholang.normalizer2.env.{BoundVarWriter, FreeVarReader, FreeVarWriter}
+import io.rhonix.rholang.ast.rholang.Absyn.{Case, CaseImpl, PMatch, Proc}
+import io.rhonix.rholang.{MatchCaseN, MatchN}
+
+import scala.jdk.CollectionConverters.*
+
+object MatchNormalizer {
+  def normalizerMatch[F[_]: Sync: NormalizerRec, T <: VarSort: BoundVarWriter: FreeVarReader: FreeVarWriter](
+    p: PMatch,
+  ): F[MatchN] = {
+    def liftCase(c: Case): F[(Proc, Proc)] = c match {
+      case ci: CaseImpl => (ci.proc_1, ci.proc_2).pure
+      case _            => UnrecognizedNormalizerError("Unexpected Case implementation.").raiseError
+    }
+
+    for {
+      targetResult <- BoundVarWriter[T].withCopyBoundVarScope(() => NormalizerRec[F].normalize(p.proc_))
+      cases        <- p.listcase_.asScala.toList.traverse(liftCase)
+
+      initAcc      = Vector[MatchCaseN]()
+      casesResult <- cases.foldM(initAcc) { case (acc, (pattern, caseBody)) =>
+                       for {
+                         // Normalize pattern in a fresh bound and free variables scope
+                         // TODO: extract two nested `with...` to `withNewVarScope` extension method
+                         patternTuple <- BoundVarWriter[T].withNewBoundVarScope(() =>
+                                           FreeVarWriter[T].withNewFreeVarScope(() =>
+                                             for {
+                                               pattern     <- NormalizerRec[F].normalize(pattern)
+                                               // Get free variables from the pattern
+                                               freeVars     = FreeVarReader[T].getFreeVars
+                                               freeVarCount = FreeVarReader[T].countNoWildcards
+                                             } yield (pattern, freeVars, freeVarCount),
+                                           ),
+                                         )
+
+                         (patternResult, freeVars, freeVarCount) = patternTuple
+
+                         // Bound free variables in the current scope
+                         _ = BoundVarWriter[T].absorbFree(freeVars)
+
+                         // Normalize body in the current bound and free variables scope
+                         caseBodyResult <- NormalizerRec[F].normalize(caseBody)
+                       } yield MatchCaseN(patternResult, caseBodyResult, freeVarCount) +: acc
+                     }
+    } yield MatchN(targetResult, casesResult.reverse)
+  }
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/NormalizerRec.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/NormalizerRec.scala
@@ -1,12 +1,14 @@
 package coop.rchain.rholang.normalizer2
 
 import io.rhonix.rholang.ParN
-import io.rhonix.rholang.ast.rholang.Absyn.Proc
+import io.rhonix.rholang.ast.rholang.Absyn.{Name, Proc}
 
 trait NormalizerRec[F[_]] {
   def normalize(proc: Proc): F[ParN]
+
+  def normalize(proc: Name): F[ParN]
 }
 
 object NormalizerRec {
-  def apply[F[_]](implicit instance: NormalizerRec[F]): NormalizerRec[F] = instance
+  def apply[F[_]](implicit instance: NormalizerRec[F]): instance.type = instance
 }

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/NormalizerRec.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/NormalizerRec.scala
@@ -1,12 +1,18 @@
 package coop.rchain.rholang.normalizer2
 
 import io.rhonix.rholang.ParN
-import io.rhonix.rholang.ast.rholang.Absyn.{Name, Proc}
+import io.rhonix.rholang.ast.rholang.Absyn.{Name, NameRemainder, Proc, ProcRemainder}
 
 trait NormalizerRec[F[_]] {
   def normalize(proc: Proc): F[ParN]
 
   def normalize(proc: Name): F[ParN]
+
+  // TODO: Remove when reminder will be replaced with more general spread operator.
+
+  def normalize(proc: ProcRemainder): F[ParN]
+
+  def normalize(proc: NameRemainder): F[ParN]
 }
 
 object NormalizerRec {

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/NormalizerRec.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/NormalizerRec.scala
@@ -1,0 +1,12 @@
+package coop.rchain.rholang.normalizer2
+
+import io.rhonix.rholang.ParN
+import io.rhonix.rholang.ast.rholang.Absyn.Proc
+
+trait NormalizerRec[F[_]] {
+  def normalize(proc: Proc): F[ParN]
+}
+
+object NormalizerRec {
+  def apply[F[_]](implicit instance: NormalizerRec[F]): NormalizerRec[F] = instance
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/ParNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/ParNormalizer.scala
@@ -1,0 +1,14 @@
+package coop.rchain.rholang.normalizer2
+
+import cats.Apply
+import cats.syntax.all.*
+import io.rhonix.rholang.ParN
+import io.rhonix.rholang.ast.rholang.Absyn.PPar
+
+object ParNormalizer {
+  def normalizePar[F[_]: Apply: NormalizerRec](p: PPar): F[ParN] =
+    NormalizerRec[F]
+      .normalize(p.proc_1)
+      .product(NormalizerRec[F].normalize(p.proc_2))
+      .map((ParN.combine _).tupled)
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/VarNormalizer.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/VarNormalizer.scala
@@ -1,0 +1,54 @@
+package coop.rchain.rholang.normalizer2
+
+import cats.effect.Sync
+import cats.syntax.all.*
+import coop.rchain.rholang.interpreter.compiler.*
+import coop.rchain.rholang.interpreter.errors.{
+  TopLevelWildcardsNotAllowedError,
+  UnexpectedProcContext,
+  UnexpectedReuseOfProcContextFree,
+}
+import coop.rchain.rholang.normalizer2.env.{BoundVarReader, FreeVarReader, FreeVarWriter}
+import io.rhonix.rholang.ast.rholang.Absyn.{PVar, ProcVarVar, ProcVarWildcard}
+import io.rhonix.rholang.{BoundVarN, FreeVarN, VarN, WildcardN}
+
+object VarNormalizer {
+  def normalizeVar[F[_]: Sync](
+    p: PVar,
+  )(implicit brEnv: BoundVarReader[VarSort], frEnv: FreeVarReader[VarSort], fwEnv: FreeVarWriter[VarSort]): F[VarN] =
+    Sync[F].defer {
+      p.procvar_ match {
+        case pvv: ProcVarVar =>
+          val pos = SourcePosition(pvv.line_num, pvv.col_num)
+
+          brEnv.getBoundVar(pvv.var_) match {
+            case Some(BoundContext(level, ProcSort, _)) =>
+              (BoundVarN(level): VarN).pure[F]
+
+            case Some(BoundContext(_, NameSort, sourcePosition)) =>
+              UnexpectedProcContext(pvv.var_, sourcePosition, pos).raiseError
+
+            case None =>
+              frEnv.getFreeVar(pvv.var_) match {
+                case None =>
+                  val index = fwEnv.putFreeVar(pvv.var_, ProcSort, pos)
+                  (FreeVarN(index): VarN).pure[F]
+
+                case Some(FreeContext(_, _, firstSourcePosition)) =>
+                  UnexpectedReuseOfProcContextFree(pvv.var_, firstSourcePosition, pos).raiseError
+              }
+          }
+
+        case _: ProcVarWildcard =>
+          val pos = SourcePosition(p.line_num, p.col_num)
+
+          if (!frEnv.topLevel) {
+            fwEnv.putWildcard(pos)
+
+            (WildcardN: VarN).pure[F]
+          } else {
+            TopLevelWildcardsNotAllowedError(s"_ (wildcard) at $pos").raiseError
+          }
+      }
+    }
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/BoundVarReader.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/BoundVarReader.scala
@@ -1,0 +1,20 @@
+package coop.rchain.rholang.normalizer2.env
+
+import coop.rchain.rholang.interpreter.compiler.BoundContext
+
+trait BoundVarReader[T] {
+  // Bound variables operations
+
+  /** Gets bound variable by name, current level */
+  def getBoundVar(name: String): Option[BoundContext[T]]
+
+  /** Finds bound variable, searching parent levels */
+  def findBoundVar(name: String): Option[(BoundContext[T], Int)]
+
+  /** Bounded variables count */
+  def boundVarCount: Int
+}
+
+object BoundVarReader {
+  def apply[T](implicit instance: BoundVarReader[T]): BoundVarReader[T] = instance
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/BoundVarWriter.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/BoundVarWriter.scala
@@ -1,0 +1,24 @@
+package coop.rchain.rholang.normalizer2.env
+
+import coop.rchain.rholang.interpreter.compiler.{FreeContext, IdContext}
+
+trait BoundVarWriter[T] {
+  // Bound variables operations
+
+  /** Inserts new variables in bound map  */
+  def putBoundVar(bindings: Seq[IdContext[T]]): Seq[Int]
+
+  def absorbFree(binders: Seq[FreeContext[T]]): Unit
+
+  // Scope operations
+
+  /** Runs functions in an empty bound variables scope (preserving history) */
+  def withNewBoundVarScope[R](scopeFn: () => R): R
+
+  /** Runs functions in an copy of this bound variables scope (preserving history) */
+  def withCopyBoundVarScope[R](scopeFn: () => R): R
+}
+
+object BoundVarWriter {
+  def apply[T](implicit instance: BoundVarWriter[T]): BoundVarWriter[T] = instance
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/FreeVarReader.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/FreeVarReader.scala
@@ -11,9 +11,6 @@ trait FreeVarReader[T] {
   /** Gets free variable */
   def getFreeVar(name: String): Option[FreeContext[T]]
 
-  /** Returns count of free variables without wildcards */
-  def countNoWildcards: Int;
-
   // Scope operations
 
   /** Flag if free variable scope is on top level, meaning not within the pattern */

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/FreeVarReader.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/FreeVarReader.scala
@@ -1,0 +1,25 @@
+package coop.rchain.rholang.normalizer2.env
+
+import coop.rchain.rholang.interpreter.compiler.FreeContext
+
+trait FreeVarReader[T] {
+  // Free variables operations
+
+  /** Gets all free variables */
+  def getFreeVars: Seq[FreeContext[T]]
+
+  /** Gets free variable */
+  def getFreeVar(name: String): Option[FreeContext[T]]
+
+  /** Returns count of free variables without wildcards */
+  def countNoWildcards: Int;
+
+  // Scope operations
+
+  /** Flag if free variable scope is on top level, meaning not within the pattern */
+  def topLevel: Boolean
+}
+
+object FreeVarReader {
+  def apply[T](implicit instance: FreeVarReader[T]): FreeVarReader[T] = instance
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/FreeVarWriter.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/FreeVarWriter.scala
@@ -1,0 +1,22 @@
+package coop.rchain.rholang.normalizer2.env
+
+import coop.rchain.rholang.interpreter.compiler.{IdContext, SourcePosition}
+
+trait FreeVarWriter[T] {
+  // Free variables operations
+
+  /** Puts free variables to the context */
+  def putFreeVar(binding: IdContext[T]): Int
+
+  /** Puts wildcard to the context */
+  def putWildcard(source_position: SourcePosition): Unit
+
+  // Scope operations
+
+  /** Runs functions in an empty free variables scope (preserving history) */
+  def withNewFreeVarScope[R](scopeFn: () => R): R
+}
+
+object FreeVarWriter {
+  def apply[T](implicit instance: FreeVarWriter[T]): FreeVarWriter[T] = instance
+}

--- a/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/HistoryChain.scala
+++ b/legacy/src/main/scala/coop/rchain/rholang/normalizer2/env/HistoryChain.scala
@@ -1,0 +1,16 @@
+package coop.rchain.rholang.normalizer2.env
+
+final case class HistoryChain[T](chain: collection.mutable.ListBuffer[T]) {
+
+  def current(): T = chain.last
+
+  def depth: Int = chain.length
+
+  def iter: Iterator[T] = chain.iterator
+
+  def push(t: T) = chain.append(t)
+
+  def pushCopy() = this.push(chain.last)
+
+  def pop() = chain.remove(chain.length - 1)
+}

--- a/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala
@@ -1,0 +1,44 @@
+package coop.rchain.rholang.normalizer2
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import io.rhonix.rholang.ast.rholang.Absyn.{GroundInt, PGround, PPar, Proc}
+import io.rhonix.rholang.{NilN, ParN}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class ParNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
+
+  "Par normalizer" should "delegate recursive call to the dependency" in {
+    forAll { (s1: String, s2: String) =>
+      // Construct mock Par object
+      val i1  = new GroundInt(s1)
+      val i2  = new GroundInt(s2)
+      val g1  = new PGround(i1)
+      val g2  = new PGround(i2)
+      val par = new PPar(g1, g2)
+
+      import collection.mutable.ListBuffer
+
+      // List of actual arguments to recursive call
+      val args = ListBuffer[Proc]()
+
+      // Mock implementation of recursive normalizer
+      implicit val normalizerRec = new NormalizerRec[IO] {
+        override def normalize(proc: Proc): IO[ParN] = {
+          args.append(proc)
+          NilN.pure[IO]
+        }
+      }
+
+      // Run Par normalizer
+      ParNormalizer.normalizePar[IO](par).unsafeRunSync()
+
+      // Expect both sides of par to be normalized in sequence
+      args shouldBe ListBuffer(g1, g2)
+    }
+  }
+
+}

--- a/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.normalizer2
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
-import io.rhonix.rholang.ast.rholang.Absyn.{GroundInt, PGround, PPar, Proc}
+import io.rhonix.rholang.ast.rholang.Absyn.{GroundInt, Name, PGround, PPar, Proc}
 import io.rhonix.rholang.{NilN, ParN}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,6 +31,9 @@ class ParNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with M
           args.append(proc)
           NilN.pure[IO]
         }
+
+        // TODO: Check calls to normalize Name also.
+        override def normalize(proc: Name): IO[ParN] = ???
       }
 
       // Run Par normalizer

--- a/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala
+++ b/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.normalizer2
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
-import io.rhonix.rholang.ast.rholang.Absyn.{GroundInt, Name, PGround, PPar, Proc}
+import io.rhonix.rholang.ast.rholang.Absyn.{GroundInt, Name, NameRemainder, PGround, PPar, Proc, ProcRemainder}
 import io.rhonix.rholang.{NilN, ParN}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -32,8 +32,13 @@ class ParNormalizerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with M
           NilN.pure[IO]
         }
 
-        // TODO: Check calls to normalize Name also.
+        // Other normalizer overloads should not be called.
+
         override def normalize(proc: Name): IO[ParN] = ???
+
+        override def normalize(proc: ProcRemainder): IO[ParN] = ???
+
+        override def normalize(proc: NameRemainder): IO[ParN] = ???
       }
 
       // Run Par normalizer


### PR DESCRIPTION
## Overview

This PR contains the base part of the technique used to restructure compiler code.

As a starting point contains the example for the normalizer, but applies to reducer also. The environment is defined as DSL or as explicit dependency of the normalizer functions. Currently, environment is bound and free variables with the scope management.

Dependencies are defined as implicit parameters and can be defined with _context bounds_ Scala syntax.
https://github.com/gorki-network/node/blob/8ce13c5434481ec5eeb2f49a6608ed8674eb2e7d/legacy/src/main/scala/coop/rchain/rholang/normalizer2/MatchNormalizer.scala#L14-L16

Or more directly as implicit parameters.
https://github.com/gorki-network/node/blob/8ce13c5434481ec5eeb2f49a6608ed8674eb2e7d/legacy/src/main/scala/coop/rchain/rholang/normalizer2/VarNormalizer.scala#L16-L18

The new design make dependency more explicit which restrict the access to the environment so different AST nodes can specify dependencies in a more specific way. This improves security and correctness of the code.
Testing is much easier also. Here is the example of a test for normalizer for `Par` which just checks the only thing that normalizer can do, to recursively call normalizer for each branch of `Par`.
https://github.com/gorki-network/node/blob/d2aef837542b2a175ba1566522da02b56cd9d25a/legacy/src/test/scala/coop/rchain/rholang/normalizer2/ParNormalizerSpec.scala#L14-L42

## How to read the code / abstraction

It's important that we think about normalizer functions as interactions between different environments/dependencies. This interaction defines the behavior driven by the structure and data of the AST node.

#### To simplify mind model we can see AST nodes in two groups.
1. **Terminal** The simple nodes that gives resulting normalized object without requiring dependencies. Or more complicated nodes with environment interactions, but still without recursive call to normalizer on nested nodes. They are like *constants* or *terminal* nodes.
2. **Recursive** Nodes with recursive definition to inner nodes where normalizer functions depends on `NormalizerRec` environment/dependency are *derived* or *recursive* nodes. It can be helpful to think about these nodes in groups of how many recursive nodes they define.

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
