### PR TITLE
Digital signature traits and data classes, Secp256k1 implementation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val settingsScala2 = commonSettings ++ Seq(
 
 lazy val all = (project in file("."))
   .settings(commonSettings*)
-  .aggregate(sdk, weaver, dproc, db, node, rholang, legacy, sim, diag, macros)
+  .aggregate(sdk, weaver, dproc, db, node, rholang, legacy, sim, diag, macros, secp256k1)
 
 lazy val sdk = (project in file("sdk"))
 //  .settings(settingsScala3*) // Not supported in IntelliJ Scala plugin
@@ -86,7 +86,7 @@ lazy val node = (project in file("node"))
       Resolver.sonatypeOssRepos("releases") ++
         Resolver.sonatypeOssRepos("snapshots"),
   )
-  .dependsOn(sdk % "compile->compile;test->test", weaver, dproc, diag, db)
+  .dependsOn(sdk % "compile->compile;test->test", weaver, dproc, diag, db, secp256k1)
 
 // Diagnostics
 lazy val diag = (project in file("diag"))
@@ -177,3 +177,4 @@ lazy val secp256k1 = (project in file("secp256k1"))
     },
     Compile / sourceGenerators += pullNative.taskValue,
   )
+  .dependsOn(sdk)

--- a/build.sbt
+++ b/build.sbt
@@ -185,4 +185,4 @@ lazy val secp256k1 = (project in file("secp256k1"))
     // NOTE: this is not called on `compile` but when tests are called or on assembly
     Compile / resourceGenerators += pullNative.taskValue,
   )
-  .dependsOn(sdk)
+  .dependsOn(sdk % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -159,3 +159,7 @@ lazy val macros = (project in file("macros"))
   .settings(settingsScala2*)
   .settings(libraryDependencies += scalaReflect(scala2Version))
   .dependsOn(sdk)
+
+lazy val secp256k1 = (project in file("secp256k1"))
+  .settings(settingsScala2*)
+  .settings(libraryDependencies ++= common :: log)

--- a/project/Secp256k1.scala
+++ b/project/Secp256k1.scala
@@ -19,18 +19,17 @@ object Secp256k1 {
     taskKey[Unit]("Pull native libraries for Secp256k1")
 
   def pullSecp256k1(base: File): Set[File] = {
-    println("Missing Secp256k1 native library, downloading...")
     new File(base.toPath.toString).mkdirs()
-    val linux       = (base.toPath / "secp256k1-native-linux-x86_64.so").toFile
-    val osx_x64     = (base.toPath / "secp256k1-native-osx-x86_64.dylib").toFile
-    val osx_aarch64 = (base.toPath / "secp256k1-native-osx-aarch64.dylib").toFile
+    val linux_x86_x64_local = (base.toPath / "secp256k1-native-linux-x86_64.so").toFile
+    val osx_x86_x64_local   = (base.toPath / "secp256k1-native-osx-x86_64.dylib").toFile
+    val osx_aarch64_local   = (base.toPath / "secp256k1-native-osx-aarch64.dylib").toFile
 
-    url(linux_x86_x64_remote) #> file(linux.getAbsolutePath) !
+    url(linux_x86_x64_remote) #> file(linux_x86_x64_local.getAbsolutePath) !
 
-    url(osx_x86_x64_remote) #> file(osx_x64.getAbsolutePath) !
+    url(osx_x86_x64_remote) #> file(osx_x86_x64_local.getAbsolutePath) !
 
-    url(osx_aarch64_remote) #> file(osx_aarch64.getAbsolutePath) !
+    url(osx_aarch64_remote) #> file(osx_aarch64_local.getAbsolutePath) !
 
-    Set(linux, osx_x64, osx_aarch64)
+    Set(linux_x86_x64_local, osx_x86_x64_local, osx_aarch64_local)
   }
 }

--- a/project/Secp256k1.scala
+++ b/project/Secp256k1.scala
@@ -1,0 +1,36 @@
+import sbt.{file, pathToPathOps, taskKey, url}
+
+import java.io.File
+import scala.language.postfixOps
+import scala.sys.process.*
+
+object Secp256k1 {
+  lazy val pullNative = taskKey[Seq[File]]("Pull native libs from remote repository")
+
+  // TODO pull from https://github.com/gorki-network/secp256k1-native after CD if complete
+  lazy val linux_x86_x64_remote =
+    "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-linux-x86_64.so"
+  lazy val osx_x86_x64_remote   =
+    "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-osx-x86_64.dylib"
+  lazy val osx_aarch64_remote   =
+    "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-osx-aarch64.dylib"
+
+  lazy val pullNativeLibs =
+    taskKey[Unit]("Pull native libraries for Secp256k1")
+
+  def pullSecp256k1(base: File): Set[File] = {
+    println("Missing Secp256k1 native library, downloading...")
+    new File(base.toPath.toString).mkdirs()
+    val linux       = (base.toPath / "secp256k1-native-linux-x86_64.so").toFile
+    val osx_x64     = (base.toPath / "secp256k1-native-osx-x86_64.dylib").toFile
+    val osx_aarch64 = (base.toPath / "secp256k1-native-osx-aarch64.dylib").toFile
+
+    url(linux_x86_x64_remote) #> file(linux.getAbsolutePath) !
+
+    url(osx_x86_x64_remote) #> file(osx_x64.getAbsolutePath) !
+
+    url(osx_aarch64_remote) #> file(osx_aarch64.getAbsolutePath) !
+
+    Set(linux, osx_x64, osx_aarch64)
+  }
+}

--- a/project/Secp256k1.scala
+++ b/project/Secp256k1.scala
@@ -8,11 +8,11 @@ object Secp256k1 {
   lazy val pullNative = taskKey[Seq[File]]("Pull native libs from remote repository")
 
   // TODO pull from https://github.com/gorki-network/secp256k1-native after CD if complete
-  lazy val linux_x86_x64_remote =
+  private lazy val linux_x86_x64_remote =
     "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-linux-x86_64.so"
-  lazy val osx_x86_x64_remote   =
+  private lazy val osx_x86_x64_remote   =
     "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-osx-x86_64.dylib"
-  lazy val osx_aarch64_remote   =
+  private lazy val osx_aarch64_remote   =
     "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-osx-aarch64.dylib"
 
   lazy val pullNativeLibs =

--- a/sdk/src/main/scala/sdk/crypto/ECDSA.scala
+++ b/sdk/src/main/scala/sdk/crypto/ECDSA.scala
@@ -1,0 +1,7 @@
+package sdk.crypto
+
+// Elliptic Curve Digital Signature Algorithm
+trait ECDSA extends KeyGen with Signer with Verifier {
+  // Size of data for signing / signature verification
+  val dataSize: Int
+}

--- a/sdk/src/main/scala/sdk/crypto/KeyGen.scala
+++ b/sdk/src/main/scala/sdk/crypto/KeyGen.scala
@@ -1,0 +1,5 @@
+package sdk.crypto
+
+trait KeyGen {
+  def newKeyPair: (SecKey, PubKey)
+}

--- a/sdk/src/main/scala/sdk/crypto/PubKey.scala
+++ b/sdk/src/main/scala/sdk/crypto/PubKey.scala
@@ -1,0 +1,3 @@
+package sdk.crypto
+
+final class PubKey(val value: Array[Byte]) extends AnyVal

--- a/sdk/src/main/scala/sdk/crypto/SecKey.scala
+++ b/sdk/src/main/scala/sdk/crypto/SecKey.scala
@@ -1,0 +1,3 @@
+package sdk.crypto
+
+final class SecKey(val value: Array[Byte]) extends AnyVal

--- a/sdk/src/main/scala/sdk/crypto/Sig.scala
+++ b/sdk/src/main/scala/sdk/crypto/Sig.scala
@@ -1,0 +1,3 @@
+package sdk.crypto
+
+final class Sig(val value: Array[Byte]) extends AnyVal

--- a/sdk/src/main/scala/sdk/crypto/Signer.scala
+++ b/sdk/src/main/scala/sdk/crypto/Signer.scala
@@ -1,0 +1,7 @@
+package sdk.crypto
+
+import scala.util.Try
+
+trait Signer {
+  def sign(data: Array[Byte], privateKey: SecKey): Try[Sig]
+}

--- a/sdk/src/main/scala/sdk/crypto/Verifier.scala
+++ b/sdk/src/main/scala/sdk/crypto/Verifier.scala
@@ -1,0 +1,7 @@
+package sdk.crypto
+
+import scala.util.Try
+
+trait Verifier {
+  def verify(data: Array[Byte], signature: Sig, publicKey: PubKey): Try[Boolean]
+}

--- a/sdk/src/test/scala/sdk/crypto/ECDSASpec.scala
+++ b/sdk/src/test/scala/sdk/crypto/ECDSASpec.scala
@@ -1,0 +1,19 @@
+package sdk.crypto
+
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Success
+
+object ECDSASpec extends Matchers {
+  // This spec is to be used for all ECDSA implementations
+  def apply(ecdsa: ECDSA): Assertion = {
+    val data   = Array.fill(ecdsa.dataSize)(1.toByte)
+    val (s, p) = ecdsa.newKeyPair
+    val sig    = ecdsa.sign(data, s).get
+    // Successful verification
+    ecdsa.verify(data, sig, p) shouldBe Success(true)
+    // Unsuccessful verification
+    ecdsa.verify(data, new Sig(sig.value.tail :+ 0.toByte), p) shouldBe Success(false)
+  }
+}

--- a/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.crypto;
+package org.bitcoin;
 
 import java.math.BigInteger;
 import java.nio.Buffer;
@@ -23,9 +23,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import static org.crypto.NativeSecp256k1Util.assertEquals;
-import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
 /**
  * <p>This class holds native methods to handle ECDSA verification.</p>
@@ -37,10 +34,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * and `make` then copy `.libs/libsecp256k1.so` to your system library path
  * or point the JVM to the folder containing it with -Djava.library.path
  * </p>
- *
- * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2267
  */
-@Deprecated
 public class NativeSecp256k1 {
 
     private static final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
@@ -59,7 +53,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException never thrown?
      */
     public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
+        assert (data.length == 32 && signature.length <= 520 && pub.length <= 520);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 520) {
@@ -89,7 +83,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException on bad signature length
      */
     public static byte[] sign(byte[] data, byte[] sec) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(data.length == 32 && sec.length <= 32);
+        assert (data.length == 32 && sec.length <= 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + 32) {
@@ -126,7 +120,7 @@ public class NativeSecp256k1 {
      * @return true if valid, false if invalid
      */
     public static boolean secKeyVerify(byte[] seckey) {
-        checkArgument(seckey.length == 32);
+        assert (seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seckey.length) {
@@ -154,7 +148,7 @@ public class NativeSecp256k1 {
      */
     // TODO add a 'compressed' arg
     public static byte[] computePubkey(byte[] seckey) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(seckey.length == 32);
+        assert (seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seckey.length) {
@@ -219,7 +213,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException assertion failure
      */
     public static byte[] privKeyTweakMul(byte[] privkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(privkey.length == 32);
+        assert (privkey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < privkey.length + tweak.length) {
@@ -260,7 +254,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException assertion failure
      */
     public static byte[] privKeyTweakAdd(byte[] privkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(privkey.length == 32);
+        assert (privkey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < privkey.length + tweak.length) {
@@ -301,7 +295,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException assertion failure
      */
     public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+        assert (pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
@@ -342,7 +336,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException assertion failure
      */
     public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+        assert (pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
@@ -383,7 +377,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException assertion failure
      */
     public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(seckey.length <= 32 && pubkey.length <= 65);
+        assert (seckey.length <= 32 && pubkey.length <= 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + pubkey.length) {
@@ -420,7 +414,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException never thrown?
      */
     public static synchronized boolean randomize(byte[] seed) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(seed.length == 32 || seed == null);
+        assert (seed.length == 32 || seed == null);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seed.length) {
@@ -446,7 +440,7 @@ public class NativeSecp256k1 {
      * @throws NativeSecp256k1Util.AssertFailException assertion failure
      */
     public static byte[] schnorrSign(byte[] data, byte[] sec) throws NativeSecp256k1Util.AssertFailException {
-        checkArgument(data.length == 32 && sec.length <= 32);
+        assert (data.length == 32 && sec.length <= 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null) {

--- a/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright 2013 Google Inc.
+ * Copyright 2014-2016 the libsecp256k1 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.crypto;
+
+import java.math.BigInteger;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.crypto.NativeSecp256k1Util.assertEquals;
+import static org.bitcoinj.base.internal.Preconditions.checkArgument;
+
+/**
+ * <p>This class holds native methods to handle ECDSA verification.</p>
+ *
+ * <p>You can find an example library that can be used for this at https://github.com/bitcoin/secp256k1</p>
+ *
+ * <p>To build secp256k1 for use with bitcoinj, run
+ * `./configure --enable-jni --enable-experimental --enable-module-schnorr --enable-module-ecdh`
+ * and `make` then copy `.libs/libsecp256k1.so` to your system library path
+ * or point the JVM to the folder containing it with -Djava.library.path
+ * </p>
+ *
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2267
+ */
+@Deprecated
+public class NativeSecp256k1 {
+
+    private static final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
+    private static final Lock r = rwl.readLock();
+    private static final Lock w = rwl.writeLock();
+    private static ThreadLocal<ByteBuffer> nativeECDSABuffer = new ThreadLocal<>();
+
+    /**
+     * Verifies the given secp256k1 signature in native code. Calling when enabled == false is undefined (probably
+     * library not loaded)
+     *
+     * @param data      The data which was signed, must be exactly 32 bytes
+     * @param signature The signature
+     * @param pub       The public key which did the signing
+     * @return true if correct signature
+     * @throws NativeSecp256k1Util.AssertFailException never thrown?
+     */
+    public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 520) {
+            byteBuff = ByteBuffer.allocateDirect(520);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(data);
+        byteBuff.put(signature);
+        byteBuff.put(pub);
+
+        r.lock();
+        try {
+            return secp256k1_ecdsa_verify(byteBuff, Secp256k1Context.getContext(), signature.length, pub.length) == 1;
+        } finally {
+            r.unlock();
+        }
+    }
+
+    /**
+     * libsecp256k1 Create an ECDSA signature.
+     *
+     * @param data Message hash, 32 bytes
+     * @param sec  Secret key, 32 bytes
+     * @return sig byte array of signature
+     * @throws NativeSecp256k1Util.AssertFailException on bad signature length
+     */
+    public static byte[] sign(byte[] data, byte[] sec) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(data.length == 32 && sec.length <= 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 32 + 32) {
+            byteBuff = ByteBuffer.allocateDirect(32 + 32);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(data);
+        byteBuff.put(sec);
+
+        byte[][] retByteArray;
+
+        r.lock();
+        try {
+            retByteArray = secp256k1_ecdsa_sign(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] sigArr = retByteArray[0];
+        int sigLen = new BigInteger(new byte[]{retByteArray[1][0]}).intValue();
+        int retVal = new BigInteger(new byte[]{retByteArray[1][1]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(sigArr.length, sigLen, "Got bad signature length.");
+
+        return retVal == 0 ? new byte[0] : sigArr;
+    }
+
+    /**
+     * libsecp256k1 Seckey Verify - returns 1 if valid, 0 if invalid
+     *
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @return true if valid, false if invalid
+     */
+    public static boolean secKeyVerify(byte[] seckey) {
+        checkArgument(seckey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seckey.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(seckey);
+
+        r.lock();
+        try {
+            return secp256k1_ec_seckey_verify(byteBuff, Secp256k1Context.getContext()) == 1;
+        } finally {
+            r.unlock();
+        }
+    }
+
+    /**
+     * libsecp256k1 Compute Pubkey - computes public key from secret key
+     *
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @return pubkey ECDSA Public key, 33 or 65 bytes
+     * @throws NativeSecp256k1Util.AssertFailException if bad pubkey length
+     */
+    // TODO add a 'compressed' arg
+    public static byte[] computePubkey(byte[] seckey) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(seckey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seckey.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(seckey);
+
+        byte[][] retByteArray;
+
+        r.lock();
+        try {
+            retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+        int pubLen = new BigInteger(new byte[]{retByteArray[1][0]}).intValue();
+        int retVal = new BigInteger(new byte[]{retByteArray[1][1]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        return retVal == 0 ? new byte[0] : pubArr;
+    }
+
+    /**
+     * libsecp256k1 Cleanup - This destroys the secp256k1 context object This should be called at the end of the program
+     * for proper cleanup of the context.
+     */
+    public static synchronized void cleanup() {
+        w.lock();
+        try {
+            secp256k1_destroy_context(Secp256k1Context.getContext());
+        } finally {
+            w.unlock();
+        }
+    }
+
+    /**
+     * Clone context
+     *
+     * @return context reference
+     */
+    public static long cloneContext() {
+        r.lock();
+        try {
+            return secp256k1_ctx_clone(Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+    }
+
+    /**
+     * libsecp256k1 PrivKey Tweak-Mul - Tweak privkey by multiplying to it
+     *
+     * @param tweak   some bytes to tweak with
+     * @param privkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws NativeSecp256k1Util.AssertFailException assertion failure
+     */
+    public static byte[] privKeyTweakMul(byte[] privkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(privkey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < privkey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(privkey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(privkey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_privkey_tweak_mul(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] privArr = retByteArray[0];
+
+        int privLen = (byte) new BigInteger(new byte[]{retByteArray[1][0]}).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[]{retByteArray[1][1]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(privArr.length, privLen, "Got bad pubkey length.");
+
+        NativeSecp256k1Util.assertEquals(retVal, 1, "Failed return value check.");
+
+        return privArr;
+    }
+
+    /**
+     * libsecp256k1 PrivKey Tweak-Add - Tweak privkey by adding to it
+     *
+     * @param tweak   some bytes to tweak with
+     * @param privkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws NativeSecp256k1Util.AssertFailException assertion failure
+     */
+    public static byte[] privKeyTweakAdd(byte[] privkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(privkey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < privkey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(privkey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(privkey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_privkey_tweak_add(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] privArr = retByteArray[0];
+
+        int privLen = (byte) new BigInteger(new byte[]{retByteArray[1][0]}).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[]{retByteArray[1][1]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(privArr.length, privLen, "Got bad pubkey length.");
+
+        NativeSecp256k1Util.assertEquals(retVal, 1, "Failed return value check.");
+
+        return privArr;
+    }
+
+    /**
+     * libsecp256k1 PubKey Tweak-Add - Tweak pubkey by adding to it
+     *
+     * @param tweak  some bytes to tweak with
+     * @param pubkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws NativeSecp256k1Util.AssertFailException assertion failure
+     */
+    public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(pubkey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(pubkey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_pubkey_tweak_add(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+
+        int pubLen = (byte) new BigInteger(new byte[]{retByteArray[1][0]}).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[]{retByteArray[1][1]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        NativeSecp256k1Util.assertEquals(retVal, 1, "Failed return value check.");
+
+        return pubArr;
+    }
+
+    /**
+     * libsecp256k1 PubKey Tweak-Mul - Tweak pubkey by multiplying to it
+     *
+     * @param tweak  some bytes to tweak with
+     * @param pubkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws NativeSecp256k1Util.AssertFailException assertion failure
+     */
+    public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(pubkey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(pubkey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_pubkey_tweak_mul(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+
+        int pubLen = (byte) new BigInteger(new byte[]{retByteArray[1][0]}).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[]{retByteArray[1][1]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        NativeSecp256k1Util.assertEquals(retVal, 1, "Failed return value check.");
+
+        return pubArr;
+    }
+
+    /**
+     * libsecp256k1 create ECDH secret - constant time ECDH calculation
+     *
+     * @param seckey byte array of secret key used in exponentiation
+     * @param pubkey byte array of public key used in exponentiation
+     * @return the secret
+     * @throws NativeSecp256k1Util.AssertFailException assertion failure
+     */
+    public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(seckey.length <= 32 && pubkey.length <= 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 32 + pubkey.length) {
+            byteBuff = ByteBuffer.allocateDirect(32 + pubkey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(seckey);
+        byteBuff.put(pubkey);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_ecdh(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] resArr = retByteArray[0];
+        int retVal = new BigInteger(new byte[]{retByteArray[1][0]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(resArr.length, 32, "Got bad result length.");
+        NativeSecp256k1Util.assertEquals(retVal, 1, "Failed return value check.");
+
+        return resArr;
+    }
+
+    /**
+     * libsecp256k1 randomize - updates the context randomization
+     *
+     * @param seed 32-byte random seed
+     * @return true if successful, false otherwise
+     * @throws NativeSecp256k1Util.AssertFailException never thrown?
+     */
+    public static synchronized boolean randomize(byte[] seed) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(seed.length == 32 || seed == null);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seed.length) {
+            byteBuff = ByteBuffer.allocateDirect(seed.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(seed);
+
+        w.lock();
+        try {
+            return secp256k1_context_randomize(byteBuff, Secp256k1Context.getContext()) == 1;
+        } finally {
+            w.unlock();
+        }
+    }
+
+    /**
+     * @param data data to sign
+     * @param sec  secret key
+     * @return Signature or byte[0]
+     * @throws NativeSecp256k1Util.AssertFailException assertion failure
+     */
+    public static byte[] schnorrSign(byte[] data, byte[] sec) throws NativeSecp256k1Util.AssertFailException {
+        checkArgument(data.length == 32 && sec.length <= 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null) {
+            byteBuff = ByteBuffer.allocateDirect(32 + 32);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        ((Buffer) byteBuff).rewind();
+        byteBuff.put(data);
+        byteBuff.put(sec);
+
+        byte[][] retByteArray;
+
+        r.lock();
+        try {
+            retByteArray = secp256k1_schnorr_sign(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] sigArr = retByteArray[0];
+        int retVal = new BigInteger(new byte[]{retByteArray[1][0]}).intValue();
+
+        NativeSecp256k1Util.assertEquals(sigArr.length, 64, "Got bad signature length.");
+
+        return retVal == 0 ? new byte[0] : sigArr;
+    }
+
+    private static native long secp256k1_ctx_clone(long context);
+
+    private static native int secp256k1_context_randomize(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_privkey_tweak_add(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_privkey_tweak_mul(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_pubkey_tweak_add(ByteBuffer byteBuff, long context, int pubLen);
+
+    private static native byte[][] secp256k1_pubkey_tweak_mul(ByteBuffer byteBuff, long context, int pubLen);
+
+    private static native void secp256k1_destroy_context(long context);
+
+    private static native int secp256k1_ecdsa_verify(ByteBuffer byteBuff, long context, int sigLen, int pubLen);
+
+    private static native byte[][] secp256k1_ecdsa_sign(ByteBuffer byteBuff, long context);
+
+    private static native int secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_ec_pubkey_parse(ByteBuffer byteBuff, long context, int inputLen);
+
+    private static native byte[][] secp256k1_schnorr_sign(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_ecdh(ByteBuffer byteBuff, long context, int inputLen);
+}

--- a/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1Util.java
+++ b/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1Util.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2016 the libsecp256k1 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.crypto;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Assertion utilities for {@link NativeSecp256k1}
+ *
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2267
+ */
+@Deprecated
+public class NativeSecp256k1Util {
+
+    private static final Logger log = LoggerFactory.getLogger(NativeSecp256k1Util.class);
+
+    /**
+     * Compare two integers and throw {@link AssertFailException} if not equal
+     *
+     * @param val     first int
+     * @param val2    second int
+     * @param message failure error message
+     * @throws AssertFailException when ints are not equal
+     */
+    public static void assertEquals(int val, int val2, String message) throws AssertFailException {
+        if (val != val2)
+            throw new AssertFailException("FAIL: " + message);
+    }
+
+    /**
+     * Compare two booleans and throw {@link AssertFailException} if not equal
+     *
+     * @param val     first boolean
+     * @param val2    second boolean
+     * @param message failure error message
+     * @throws AssertFailException when booleans are not equal
+     */
+    public static void assertEquals(boolean val, boolean val2, String message) throws AssertFailException {
+        if (val != val2)
+            throw new AssertFailException("FAIL: " + message);
+        else
+            log.debug("PASS: " + message);
+    }
+
+    /**
+     * Compare two Strings and throw {@link AssertFailException} if not equal
+     *
+     * @param val     first String
+     * @param val2    second String
+     * @param message failure error message
+     * @throws AssertFailException when Strings are not equal
+     */
+    public static void assertEquals(String val, String val2, String message) throws AssertFailException {
+        if (!val.equals(val2))
+            throw new AssertFailException("FAIL: " + message);
+        else
+            log.debug("PASS: " + message);
+    }
+
+    /**
+     * Assertion failure exception
+     */
+    public static class AssertFailException extends Exception {
+        /**
+         * @param message The failure message
+         */
+        public AssertFailException(String message) {
+            super(message);
+        }
+    }
+}

--- a/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1Util.java
+++ b/secp256k1/src/main/java/org/bitcoin/NativeSecp256k1Util.java
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-package org.crypto;
+package org.bitcoin;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Assertion utilities for {@link NativeSecp256k1}
- *
- * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2267
  */
-@Deprecated
 public class NativeSecp256k1Util {
 
     private static final Logger log = LoggerFactory.getLogger(NativeSecp256k1Util.class);

--- a/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -20,10 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import static java.io.File.createTempFile;
 import static java.lang.System.getProperty;
@@ -61,11 +58,11 @@ public class Secp256k1Context {
                 libToLoad = extract("secp256k1-native-linux-x86_64.so");
             } else if (arch64 && osx) {
                 libToLoad = extract("secp256k1-native-osx-x86_64.dylib");
-            }  else if (arch64 && windows) {
+            } else if (arch64 && windows) {
                 libToLoad = extract("secp256k1-native-windows-x86_64.dll");
             } else if (osx_arm) {
                 libToLoad = extract("secp256k1-native-osx-aarch64.dylib");
-            } else  {
+            } else {
                 throw new RuntimeException("No secp256k1-native library to extract");
             }
             System.load(libToLoad);
@@ -73,7 +70,7 @@ public class Secp256k1Context {
         } catch (UnsatisfiedLinkError e) {
             System.out.println("UnsatisfiedLinkError: " + e.toString());
             isEnabled = false;
-        } catch (IOException e){
+        } catch (IOException e) {
             System.out.println("IOException: " + e.toString());
             isEnabled = false;
         } catch (NullPointerException e) {
@@ -112,7 +109,7 @@ public class Secp256k1Context {
     }
 
     public static long getContext() {
-        if(!enabled) return -1; //sanity check
+        if (!enabled) return -1; //sanity check
         return context;
     }
 

--- a/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -16,49 +16,103 @@
 
 package org.bitcoin;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static java.io.File.createTempFile;
+import static java.lang.System.getProperty;
+import static java.lang.Thread.currentThread;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 /**
- * This class holds the context reference used in native methods to handle ECDSA operations.
- *
- * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2267
+ * This class holds the context reference used in native methods
+ * to handle ECDSA operations.
  */
-@Deprecated
 public class Secp256k1Context {
+    private static final boolean enabled; //true if the library is loaded
+    private static final long context; //ref to pointer to context obj
 
-    private static final boolean enabled; // true if the library is loaded
-    private static final long context; // ref to pointer to context obj
 
-    private static final Logger log = LoggerFactory.getLogger(Secp256k1Context.class);
-
-    static { // static initializer
+    static { //static initializer
         boolean isEnabled = true;
         long contextRef = -1;
+
+        final String libToLoad;
+
+        final String arch = getProperty("os.arch");
+        final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
+                || "x86_64".equals(arch);
+
+        final String os = getProperty("os.name");
+        final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
+        final boolean osx = os.startsWith("Mac OS X");
+        final boolean osx_arm = "aarch64".equals(arch);
+        final boolean windows = os.startsWith("Windows");
+
         try {
-            System.loadLibrary("secp256k1");
+            if (arch64 && linux) {
+                libToLoad = extract("secp256k1-native-linux-x86_64.so");
+            } else if (arch64 && osx) {
+                libToLoad = extract("secp256k1-native-osx-x86_64.dylib");
+            }  else if (arch64 && windows) {
+                libToLoad = extract("secp256k1-native-windows-x86_64.dll");
+            } else if (osx_arm) {
+                libToLoad = extract("secp256k1-native-osx-aarch64.dylib");
+            } else  {
+                throw new RuntimeException("No secp256k1-native library to extract");
+            }
+            System.load(libToLoad);
             contextRef = secp256k1_init_context();
-        } catch (UnsatisfiedLinkError | SecurityException e) {
-            log.debug(e.toString());
+        } catch (UnsatisfiedLinkError e) {
+            System.out.println("UnsatisfiedLinkError: " + e.toString());
+            isEnabled = false;
+        } catch (IOException e){
+            System.out.println("IOException: " + e.toString());
+            isEnabled = false;
+        } catch (NullPointerException e) {
+            System.out.println("Null pointer exception: " + e.toString());
             isEnabled = false;
         }
         enabled = isEnabled;
         context = contextRef;
     }
 
-    /**
-     * @return true if enabled
-     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private static String extract(final String name) throws IOException {
+        final String suffix = name.substring(name.lastIndexOf('.'));
+        final File file;
+        try {
+            file = createTempFile("secp256k1-native-library-", suffix);
+            file.deleteOnExit();
+            final ClassLoader cl = currentThread().getContextClassLoader();
+            requireNonNull(cl.getResource(name), "Classpath resource not found");
+            try (InputStream in = cl.getResourceAsStream(name);
+                 OutputStream out = Files.newOutputStream(file.toPath())) {
+                int bytes;
+                final byte[] buffer = new byte[4_096];
+                while (-1 != (bytes = in.read(buffer))) {
+                    out.write(buffer, 0, bytes);
+                }
+            }
+            return file.getAbsolutePath();
+        } catch (final IOException e) {
+            throw new IOException("Failed to extract " + name, e);
+        }
+    }
+
     public static boolean isEnabled() {
         return enabled;
     }
 
-    /**
-     * @return context reference
-     */
     public static long getContext() {
-        if (!enabled)
-            return -1; // sanity check
+        if(!enabled) return -1; //sanity check
         return context;
     }
 

--- a/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2016 the libsecp256k1 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class holds the context reference used in native methods to handle ECDSA operations.
+ *
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2267
+ */
+@Deprecated
+public class Secp256k1Context {
+
+    private static final boolean enabled; // true if the library is loaded
+    private static final long context; // ref to pointer to context obj
+
+    private static final Logger log = LoggerFactory.getLogger(Secp256k1Context.class);
+
+    static { // static initializer
+        boolean isEnabled = true;
+        long contextRef = -1;
+        try {
+            System.loadLibrary("secp256k1");
+            contextRef = secp256k1_init_context();
+        } catch (UnsatisfiedLinkError | SecurityException e) {
+            log.debug(e.toString());
+            isEnabled = false;
+        }
+        enabled = isEnabled;
+        context = contextRef;
+    }
+
+    /**
+     * @return true if enabled
+     */
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * @return context reference
+     */
+    public static long getContext() {
+        if (!enabled)
+            return -1; // sanity check
+        return context;
+    }
+
+    private static native long secp256k1_init_context();
+}

--- a/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -44,24 +44,27 @@ public class Secp256k1Context {
         final String libToLoad;
 
         final String arch = getProperty("os.arch");
-        final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
-                || "x86_64".equals(arch);
+        final boolean x64 = "x64".equals(arch) || "amd64".equals(arch) || "x86_64".equals(arch);
+        final boolean aarch64 = "aarch64".equals(arch);
 
         final String os = getProperty("os.name");
         final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
         final boolean osx = os.startsWith("Mac OS X");
-        final boolean osx_arm = "aarch64".equals(arch);
         final boolean windows = os.startsWith("Windows");
 
+        System.out.println("Platform detected: " + os + " " + arch);
+
         try {
-            if (arch64 && linux) {
+            if (x64 && linux) {
                 libToLoad = extract("secp256k1-native-linux-x86_64.so");
-            } else if (arch64 && osx) {
+            } else if (aarch64 && linux) {
+                libToLoad = extract("secp256k1-native-linux-aarch64.so");
+            } else if (x64 && osx) {
                 libToLoad = extract("secp256k1-native-osx-x86_64.dylib");
-            } else if (arch64 && windows) {
-                libToLoad = extract("secp256k1-native-windows-x86_64.dll");
-            } else if (osx_arm) {
+            } else if (aarch64 && osx) {
                 libToLoad = extract("secp256k1-native-osx-aarch64.dylib");
+            } else if (x64 && windows) {
+                libToLoad = extract("secp256k1-native-windows-x86_64.dll");
             } else {
                 throw new RuntimeException("No secp256k1-native library to extract");
             }
@@ -89,7 +92,7 @@ public class Secp256k1Context {
             file = createTempFile("secp256k1-native-library-", suffix);
             file.deleteOnExit();
             final ClassLoader cl = currentThread().getContextClassLoader();
-            requireNonNull(cl.getResource(name), "Classpath resource not found");
+            requireNonNull(cl.getResource(name), "Classpath resource " + name + " not found");
             try (InputStream in = cl.getResourceAsStream(name);
                  OutputStream out = Files.newOutputStream(file.toPath())) {
                 int bytes;

--- a/secp256k1/src/main/java/org/bitcoin/package.scala
+++ b/secp256k1/src/main/java/org/bitcoin/package.scala
@@ -1,0 +1,7 @@
+package org
+
+// This package is a java interface to native libsecp256k1 library provided by https://github.com/bitcoin-core/secp256k1,
+// maintained and built here https://github.com/gorki-network/secp256k1-native.
+// Despite the fact that this interface is removed https://github.com/bitcoinj/bitcoinj/pull/2267 it is still good
+// enough for our purposes.
+package object bitcoin

--- a/secp256k1/src/main/scala/secp256k1/Secp256k1.scala
+++ b/secp256k1/src/main/scala/secp256k1/Secp256k1.scala
@@ -80,7 +80,7 @@ object Secp256k1 {
       val pubParams: ECPublicKeyParameters   = keypair.getPublic.asInstanceOf[ECPublicKeyParameters]
 
       new SecKey(bigIntegerToBytes(privParams.getD, secKeyLength)) ->
-        new PubKey(pubParams.getQ.getEncoded(true))
+        new PubKey(pubParams.getQ.getEncoded(false))
     }
   }
 }

--- a/secp256k1/src/main/scala/secp256k1/Secp256k1.scala
+++ b/secp256k1/src/main/scala/secp256k1/Secp256k1.scala
@@ -21,57 +21,66 @@ import scala.util.Try
  * Key generation is done using BouncyCastle
  * Verification and signing using native library.
  */
-object Secp256k1 extends Signer with Verifier with KeyGen {
+object Secp256k1 {
+  private val secKeyLength      = 32
+  private val curveName: String = "secp256k1"
 
-  override def sign(data: Array[Byte], privateKey: SecKey): Try[Sig] = Try {
-    assert(data.length == 32, s"Signed data has to be 32 bytes long for Secp256k1, but is ${data.length}")
-    assert(
-      privateKey.value.length == 32,
-      s"Private key has to be 32 bytes long for Secp256k1, but is ${privateKey.value.length}",
-    )
-    val sigArray = NativeSecp256k1.sign(data, privateKey.value)
-    new Sig(sigArray)
-  }
+  def apply: ECDSA = new ECDSA {
+    override val dataSize: Int = 32
 
-  override def verify(data: Array[Byte], signature: Sig, publicKey: PubKey): Try[Boolean] = Try {
-    NativeSecp256k1.verify(data, signature.value, publicKey.value)
-  }
+    override def sign(data: Array[Byte], privateKey: SecKey): Try[Sig] = Try {
+      assert(
+        data.length == dataSize,
+        s"Signed data has to be $dataSize bytes long for Secp256k1, but is ${data.length}",
+      )
+      assert(
+        privateKey.value.length == secKeyLength,
+        s"Private key has to be $secKeyLength bytes long for Secp256k1, but is ${privateKey.value.length}",
+      )
+      val sigArray = NativeSecp256k1.sign(data, privateKey.value)
+      new Sig(sigArray)
+    }
 
-  // This is a copy of
-  // https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java#L83-L94
-  private def bigIntegerToBytes(b: BigInteger, numBytes: Int): Array[Byte] = {
-    assert(b.signum() >= 0, () -> s"b must be positive or zero: $b")
-    assert(numBytes > 0, ()    -> s"numBytes must be positive: $numBytes")
-    val src                    = b.toByteArray
-    val dest                   = new Array[Byte](numBytes)
-    val isFirstByteOnlyForSign = src(0) == 0
-    val length                 = if (isFirstByteOnlyForSign) src.length - 1 else src.length
-    assert(length <= numBytes, () -> s"The given number does not fit in $numBytes")
-    val srcPos  = if (isFirstByteOnlyForSign) 1 else 0;
-    val destPos = numBytes - length
-    System.arraycopy(src, srcPos, dest, destPos, length)
-    dest
-  }
+    override def verify(data: Array[Byte], signature: Sig, publicKey: PubKey): Try[Boolean] = Try {
+      NativeSecp256k1.verify(data, signature.value, publicKey.value)
+    }
 
-  private val CURVE_PARAMS: X9ECParameters = CustomNamedCurves.getByName("secp256k1")
-  private val CURVE: ECDomainParameters    =
-    new ECDomainParameters(CURVE_PARAMS.getCurve, CURVE_PARAMS.getG, CURVE_PARAMS.getN, CURVE_PARAMS.getH)
-  private val secureRandom: SecureRandom   = SecureRandom.getInstanceStrong;
-  locally {
-    val _ = FixedPointUtil.precompute(CURVE_PARAMS.getG)
-  }
+    // This is a copy of
+    // https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java#L83-L94
+    private def bigIntegerToBytes(b: BigInteger, numBytes: Int): Array[Byte] = {
+      assert(b.signum() >= 0, () -> s"b must be positive or zero: $b")
+      assert(numBytes > 0, ()    -> s"numBytes must be positive: $numBytes")
+      val src                    = b.toByteArray
+      val dest                   = new Array[Byte](numBytes)
+      val isFirstByteOnlyForSign = src(0) == 0
+      val length                 = if (isFirstByteOnlyForSign) src.length - 1 else src.length
+      assert(length <= numBytes, () -> s"The given number does not fit in $numBytes")
+      val srcPos  = if (isFirstByteOnlyForSign) 1 else 0;
+      val destPos = numBytes - length
+      System.arraycopy(src, srcPos, dest, destPos, length)
+      dest
+    }
 
-  // This is a copy of
-  // https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/crypto/ECKey.java#L173-L183
-  override def newKeyPair: (SecKey, PubKey) = {
-    val generator                          = new ECKeyPairGenerator()
-    val keygenParams                       = new ECKeyGenerationParameters(CURVE, secureRandom)
-    val _                                  = generator.init(keygenParams)
-    val keypair                            = generator.generateKeyPair
-    val privParams: ECPrivateKeyParameters = keypair.getPrivate.asInstanceOf[ECPrivateKeyParameters]
-    val pubParams: ECPublicKeyParameters   = keypair.getPublic.asInstanceOf[ECPublicKeyParameters]
+    private val CURVE_PARAMS: X9ECParameters = CustomNamedCurves.getByName(curveName)
+    private val CURVE: ECDomainParameters    =
+      new ECDomainParameters(CURVE_PARAMS.getCurve, CURVE_PARAMS.getG, CURVE_PARAMS.getN, CURVE_PARAMS.getH)
+    private val secureRandom: SecureRandom   = SecureRandom.getInstanceStrong;
+    locally {
+      val _ = FixedPointUtil.precompute(CURVE_PARAMS.getG)
+    }
 
-    new SecKey(bigIntegerToBytes(privParams.getD, 32)) ->
-      new PubKey(pubParams.getQ.getEncoded(true))
+    // This is a copy of
+    // https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/crypto/ECKey.java#L173-L183
+    override def newKeyPair: (SecKey, PubKey) = {
+      val generator                          = new ECKeyPairGenerator()
+      val keygenParams                       = new ECKeyGenerationParameters(CURVE, secureRandom)
+      val _                                  = generator.init(keygenParams)
+      val keypair                            = generator.generateKeyPair
+      val privParams: ECPrivateKeyParameters = keypair.getPrivate.asInstanceOf[ECPrivateKeyParameters]
+      val pubParams: ECPublicKeyParameters   = keypair.getPublic.asInstanceOf[ECPublicKeyParameters]
+
+      new SecKey(bigIntegerToBytes(privParams.getD, secKeyLength)) ->
+        new PubKey(pubParams.getQ.getEncoded(true))
+    }
   }
 }

--- a/secp256k1/src/test/scala/Secp256k1.scala
+++ b/secp256k1/src/test/scala/Secp256k1.scala
@@ -1,0 +1,18 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sdk.crypto.Sig
+import secp256k1.Secp256k1
+
+import scala.util.Success
+
+class Secp256k1 extends AnyFlatSpec with Matchers {
+  "Secp256k1" should "sign and verify" in {
+    val data   = Array.fill(32)(1.toByte)
+    val (s, p) = Secp256k1.newKeyPair
+    val sig    = Secp256k1.sign(data, s).get
+    // Successful verification
+    Secp256k1.verify(data, sig, p) shouldBe Success(true)
+    // Unsuccessful verification
+    Secp256k1.verify(data, new Sig(sig.value.tail :+ 0.toByte), p) shouldBe Success(false)
+  }
+}

--- a/secp256k1/src/test/scala/Secp256k1.scala
+++ b/secp256k1/src/test/scala/Secp256k1.scala
@@ -1,18 +1,10 @@
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sdk.crypto.Sig
+import sdk.crypto.ECDSASpec
 import secp256k1.Secp256k1
 
-import scala.util.Success
-
 class Secp256k1 extends AnyFlatSpec with Matchers {
-  "Secp256k1" should "sign and verify" in {
-    val data   = Array.fill(32)(1.toByte)
-    val (s, p) = Secp256k1.newKeyPair
-    val sig    = Secp256k1.sign(data, s).get
-    // Successful verification
-    Secp256k1.verify(data, sig, p) shouldBe Success(true)
-    // Unsuccessful verification
-    Secp256k1.verify(data, new Sig(sig.value.tail :+ 0.toByte), p) shouldBe Success(false)
+  "Secp256k1" should "pass ECDSASpec" in {
+    ECDSASpec(Secp256k1.apply)
   }
 }


### PR DESCRIPTION
## Overview

1. Traits and data types in `sdk` to support digital signatures. 
2. Implementation for Secp256k1 curve. Native libraries from bitcoin core are used for signing and verification.

Secp256k1 implementation can be purely in java using bouncy castle. The is the path that java implementation of bitcoin took. 

The suggestion is to keep using native libraries since it it provides an experience for calling native code and gives more flexibility, since pure bounce castle singing/verification can be also done analogous to bitcoinj. In this PR key generation is done only bouncy castle, and signing / verifying using native libs. Test provided shows that this works.

This PR employs the latest version of java bindings available in bitcoinj repository. The actual native libraries for now are copied during the build process from https://github.com/nzpr/secp256k1-native/tree/aarch64. This should be replaced with https://github.com/gorki-network/secp256k1-native when continuous delivery is enabled on that repo (ptal https://github.com/gorki-network/secp256k1-native/pull/2).

This PR is verified on Mac M1 (ARM) and Linux (x64). 
To enable more platforms native binaries should be compiled in https://github.com/gorki-network/secp256k1-native repo, pulled [here](https://github.com/gorki-network/node/blob/5ac3d9575dbd314c0f53b7ca0d1272cdf472742b/project/Secp256k1.scala#L21) and loaded [here](https://github.com/gorki-network/node/blob/5ac3d9575dbd314c0f53b7ca0d1272cdf472742b/secp256k1/src/main/java/org/bitcoin/Secp256k1Context.java#L57-L70).

**Keys generated are compatible with https://tgrospic.github.io/rnode-client-js/**

Future work: 
- finish CD on repo with native libraries and adjust remote paths to pull binaries from
- pull only libraries for the platform that is required

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
