### PR TITLE
Select quorum

### DIFF
--- a/sdk/src/main/scala/sdk/consensus/SelectQuorum.scala
+++ b/sdk/src/main/scala/sdk/consensus/SelectQuorum.scala
@@ -1,0 +1,16 @@
+package sdk.consensus
+
+/**
+ * Type class for quorum selection.
+ * 
+ * Fringe advancement can be blocked if fringe is not "all across" which means protocol is not live.
+ *
+ * This type class is to select the quorum of validators that have to be included in the next fringe
+ * from the data type representing the latest fringe.
+ *
+ * Since the latest fringe is justified by set of messages on top (already produced), it gives attacker no
+ * room for manipulation (DDoS), if the next fringe senders are derived from the current one.
+ * */
+trait SelectQuorum[A, B] {
+  def next(x: A): Set[B]
+}

--- a/sdk/src/main/scala/sdk/consensus/SelectQuorumOfSuperMajorityFromStateHash.scala
+++ b/sdk/src/main/scala/sdk/consensus/SelectQuorumOfSuperMajorityFromStateHash.scala
@@ -1,0 +1,42 @@
+package sdk.consensus
+
+import sdk.primitive.ByteArray
+
+object SelectQuorumOfSuperMajorityFromStateHash {
+  private def collectSuperMajority[A](bondsMap: Seq[(A, Long)]): Seq[(A, Long)] = {
+    val totalStake         = bondsMap.map(_._2).sum
+    val superMajorityStake = totalStake * 2 / 3
+    bondsMap
+      .foldLeft(List.empty[(A, Long)], 0L) { case ((acc, stake), (sender, amount)) =>
+        if (stake > superMajorityStake) (acc, stake)
+        else ((sender -> amount) +: acc, stake + amount)
+      }
+      ._1
+  }
+
+  /**
+   * Quorum selection that deterministically derives subset of bondsMap from the byte array representing stateHash.
+   * Output set has to be super majority of the bonds map.
+   *
+   * @param bondsMap bonds map to select quorum from
+   * @tparam A type of a sender
+   * @return
+   */
+  def apply[A: Ordering](bondsMap: Map[A, Long]): SelectQuorum[ByteArray, A] =
+    new SelectQuorum[ByteArray, A] {
+      override def next(x: ByteArray): Set[A] = {
+        // Sort bonds map from current state
+        val sorted  = bondsMap.toVector.sorted
+        // Options are rotated bonds map
+        val options = LazyList.iterate(sorted) {
+          case head +: tail => tail :+ head
+          case head         => head
+        }
+        // Rotate bonds map by the first byte of the state hash and pick the first option.
+        val winner  =
+          if (sorted.nonEmpty) options.drop(x.bytes.headOption.getOrElse(0.toByte) % sorted.size).head
+          else options.head
+        collectSuperMajority(winner).map(_._1).toSet
+      }
+    }
+}

--- a/sdk/src/test/scala/sdk/consensus/SelectQuorumOfSuperMajorityFromStateHashSpec.scala
+++ b/sdk/src/test/scala/sdk/consensus/SelectQuorumOfSuperMajorityFromStateHashSpec.scala
@@ -1,0 +1,21 @@
+package sdk.consensus
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.ScalacheckShapeless.derivedArbitrary
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import sdk.primitive.ByteArray
+
+class SelectQuorumOfSuperMajorityFromStateHashSpec extends AsyncFlatSpec with Matchers with ScalaCheckPropertyChecks {
+  "next" should "be deterministic" in {
+    implicit val arbHash: Arbitrary[ByteArray] = Arbitrary {
+      Arbitrary.arbitrary[Array[Byte]].map(ByteArray(_))
+    }
+
+    forAll { (bonds: Map[Int, Long], stateHash: ByteArray) =>
+      SelectQuorumOfSuperMajorityFromStateHash(bonds).next(stateHash) shouldEqual
+        SelectQuorumOfSuperMajorityFromStateHash(bonds).next(stateHash)
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR is a suggestion for overcoming potential DDoS influence on liveness when attempting to advance new fringe. In asynchronous settings FLP impossibility (or CAP theorem) takes place, so if one replica (validator) fails, protocol is not live.

The suggestion is to use the latest observed fringe as a source of deterministic pseudo randomness. There can be multiple strategies, but implementation in this PR uses the first byte of a state hash to pick the next supermajority to be included in the fringe. Actually selecting supermajority is not necessary, it can be just a single sender.

The thesis is that that this should provide good enough protection from DDoS attacks, because the next quorum is decided only after blocks justifying the existing one already produced (take a look at the image below).

<img width="171" alt="Screenshot 2023-12-10 at 14 43 00" src="https://github.com/gorki-network/node/assets/1746367/915066db-7444-47db-bd5f-6f3e04c7ae3d">

It does not protect from replica failure, but lowers down probability of failure influencing liveness. 

If failed replica is included in the quorum, it has to recover or will be ejected but the shard.

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
