### PR TITLE
Real postgres database for Sim

### DIFF
--- a/db/src/main/scala/slick/EmbeddedH2SlickDb.scala
+++ b/db/src/main/scala/slick/EmbeddedH2SlickDb.scala
@@ -2,16 +2,18 @@ package slick
 
 import cats.effect.kernel.Resource
 import cats.effect.{Async, Sync}
+import sdk.syntax.all.*
 import slick.jdbc.H2Profile
 import slick.jdbc.JdbcBackend.Database
 import slick.migration.api.H2Dialect
-import cats.implicits.catsSyntaxApply
 
 object EmbeddedH2SlickDb {
   def apply[F[_]: Async]: Resource[F, SlickDb] =
-    Resource.liftK(Sync[F].delay(Class.forName("org.h2.Driver"))) *> {
-      val open       = Sync[F].delay(Database.forURL("jdbc:h2:mem:test", keepAliveConnection = true))
-      val dbResource = Resource.make(open)(db => Sync[F].delay(db.close()))
-      SlickDb.resource(dbResource, H2Profile, new H2Dialect)
-    }
+    Resource
+      .make(Sync[F].delay {
+        Class.forName("org.h2.Driver").void()
+
+        Database.forURL("jdbc:h2:mem:test", keepAliveConnection = true)
+      })(db => Sync[F].delay(db.close()))
+      .evalMap(SlickDb(_, H2Profile, new H2Dialect))
 }

--- a/db/src/main/scala/slick/PostgresSlickDb.scala
+++ b/db/src/main/scala/slick/PostgresSlickDb.scala
@@ -1,23 +1,23 @@
 package slick
 
 import cats.effect.{Async, Resource, Sync}
-import cats.implicits.catsSyntaxApply
+import sdk.syntax.all.*
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile
 import slick.migration.api.PostgresDialect
 
 object PostgresSlickDb {
   def apply[F[_]: Async](dbName: String, dbUser: String, dbPassword: String): Resource[F, SlickDb] =
-    Resource.liftK(Sync[F].delay(Class.forName("org.postgresql.Driver"))) *> {
-      val open       = Sync[F].delay(
+    Resource
+      .make(Sync[F].delay {
+        Class.forName("org.postgresql.Driver").void()
+
         Database.forURL(
           s"jdbc:postgresql://localhost:5432/$dbName",
           keepAliveConnection = true,
           user = dbUser,
           password = dbPassword,
-        ),
-      )
-      val dbResource = Resource.make(open)(db => Sync[F].delay(db.close()))
-      SlickDb.resource(dbResource, PostgresProfile, new PostgresDialect)
-    }
+        )
+      })(db => Sync[F].delay(db.close()))
+      .evalMap(SlickDb(_, PostgresProfile, new PostgresDialect))
 }

--- a/db/src/main/scala/slick/PostgresSlickDb.scala
+++ b/db/src/main/scala/slick/PostgresSlickDb.scala
@@ -1,0 +1,23 @@
+package slick
+
+import cats.effect.{Async, Resource, Sync}
+import cats.implicits.catsSyntaxApply
+import slick.jdbc.JdbcBackend.Database
+import slick.jdbc.PostgresProfile
+import slick.migration.api.PostgresDialect
+
+object PostgresSlickDb {
+  def apply[F[_]: Async](dbName: String, dbUser: String, dbPassword: String): Resource[F, SlickDb] =
+    Resource.liftK(Sync[F].delay(Class.forName("org.postgresql.Driver"))) *> {
+      val open       = Sync[F].delay(
+        Database.forURL(
+          s"jdbc:postgresql://localhost:5432/$dbName",
+          keepAliveConnection = true,
+          user = dbUser,
+          password = dbPassword,
+        ),
+      )
+      val dbResource = Resource.make(open)(db => Sync[F].delay(db.close()))
+      SlickDb.resource(dbResource, PostgresProfile, new PostgresDialect)
+    }
+}

--- a/db/src/main/scala/slick/SlickDb.scala
+++ b/db/src/main/scala/slick/SlickDb.scala
@@ -3,6 +3,7 @@ package slick
 import cats.effect.Resource
 import cats.effect.kernel.Async
 import cats.syntax.all.*
+import org.postgresql.util.PSQLException
 import slick.dbio.{DBIOAction, NoStream}
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.JdbcProfile
@@ -20,7 +21,14 @@ object SlickDb {
     dialect: Dialect[?],
   ): Resource[F, SlickDb] = {
     // Execute migrations each time resource is instantiated
-    def runMigration(db: Database): F[Unit] = Async[F].fromFuture(db.run(migrations.all(dialect)()).pure)
+    def runMigration(db: Database): F[Unit] =
+      Async[F].fromFuture(db.run(migrations.all(dialect)()).pure).handleErrorWith {
+        // Since slick-migration-api has no information about which migrations have been applied,
+        // re-applying migrations may throw exception about the existence of an entity in the database
+        // SQLState 42P07 means `ERROR: relation "xxx" already exists`
+        case e: PSQLException if e.getSQLState == "42P07" => ().pure
+        case error                                        => Async[F].raiseError(error)
+      }
 
     dbResource.evalMap(db => runMigration(db).as(new SlickDb(db, profile)))
   }

--- a/db/src/main/scala/slick/SlickDb.scala
+++ b/db/src/main/scala/slick/SlickDb.scala
@@ -1,6 +1,6 @@
 package slick
 
-import cats.effect.Resource
+import cats.effect.Sync
 import cats.effect.kernel.Async
 import cats.syntax.all.*
 import org.postgresql.util.PSQLException
@@ -15,14 +15,14 @@ final case class SlickDb private (private val db: Database, profile: JdbcProfile
 }
 
 object SlickDb {
-  def resource[F[_]: Async](
-    dbResource: Resource[F, Database],
+  def apply[F[_]: Async](
+    db: Database,
     profile: JdbcProfile,
     dialect: Dialect[?],
-  ): Resource[F, SlickDb] = {
-    // Execute migrations each time resource is instantiated
+  ): F[SlickDb] = {
+    // Execute migrations each time SlickDb is instantiated
     def runMigration(db: Database): F[Unit] =
-      Async[F].fromFuture(db.run(migrations.all(dialect)()).pure).handleErrorWith {
+      Async[F].fromFuture(Sync[F].delay(db.run(migrations.all(dialect)()))).handleErrorWith {
         // Since slick-migration-api has no information about which migrations have been applied,
         // re-applying migrations may throw exception about the existence of an entity in the database
         // SQLState 42P07 means `ERROR: relation "xxx" already exists`
@@ -30,6 +30,6 @@ object SlickDb {
         case error                                        => Async[F].raiseError(error)
       }
 
-    dbResource.evalMap(db => runMigration(db).as(new SlickDb(db, profile)))
+    runMigration(db).as(new SlickDb(db, profile))
   }
 }

--- a/db/src/test/scala/slick/EmbeddedPgSqlSlickDb.scala
+++ b/db/src/test/scala/slick/EmbeddedPgSqlSlickDb.scala
@@ -17,6 +17,7 @@ object EmbeddedPgSqlSlickDb {
     )
     val dbResource =
       Resource.make(open)(db => Sync[F].delay(db.close())).map(x => Database.forDataSource(x.getPostgresDatabase, None))
-    SlickDb.resource(dbResource, PostgresProfile, new PostgresDialect)
+
+    dbResource.evalMap(SlickDb(_, PostgresProfile, new PostgresDialect))
   }
 }

--- a/node/src/main/scala/node/Config.scala
+++ b/node/src/main/scala/node/Config.scala
@@ -12,6 +12,12 @@ final case class Config(
   enableInfluxDb: Boolean = false,
   @Description("Enable dev mode. WARNING: This mode is not secure and should not be used in production.")
   devMode: Boolean = false,
+  @Description("Database name")
+  dbName: String = "gorki_node_db",
+  @Description("Database user")
+  dbUser: String = "postgres",
+  @Description("Database password")
+  dbPassword: String = "postgres",
 )
 
 object Config {

--- a/sim/src/main/scala/sim/NetworkSim.scala
+++ b/sim/src/main/scala/sim/NetworkSim.scala
@@ -287,7 +287,7 @@ object NetworkSim extends IOApp {
       lfs.state.bonds.activeSet.toList.traverse(mkNode(_, db))
 
     Stream
-      .resource(slick.PostgresSlickDb[F].apply(nodeCfg.dbName, nodeCfg.dbUser, nodeCfg.dbPassword))
+      .resource(slick.PostgresSlickDb[F](nodeCfg.dbName, nodeCfg.dbUser, nodeCfg.dbPassword))
       .flatMap { db =>
         Stream
           .resource(mkNet(lfs, db))

--- a/sim/src/main/scala/sim/NetworkSim.scala
+++ b/sim/src/main/scala/sim/NetworkSim.scala
@@ -287,7 +287,7 @@ object NetworkSim extends IOApp {
       lfs.state.bonds.activeSet.toList.traverse(mkNode(_, db))
 
     Stream
-      .resource(slick.EmbeddedH2SlickDb[F])
+      .resource(slick.PostgresSlickDb[F].apply(nodeCfg.dbName, nodeCfg.dbUser, nodeCfg.dbPassword))
       .flatMap { db =>
         Stream
           .resource(mkNet(lfs, db))


### PR DESCRIPTION
## Overview

NetworkSim switched to using a real Postgres database. Connection parameters are taken from the configuration file. Added handling of entity existence errors when applying slick-migration-api migrations.

### How to create DB via `psql`

```bash
# 1. check that `postgres` user exists
id postgres

# 2. log in to the terminal as the user `postgres`
su - postgres

# 3. If we don’t remember the password, reset it with the command
sudo passwd postgres

# 4. enter to `psql` as `postgres` user
psql

# 5. execute commands to create db
postgres@naumen:~$ psql

postgres=# create database gorki_node_db;
CREATE DATABASE

postgres=# \l
                                    List of databases
     Name      |  Owner   | Encoding |   Collate   |    Ctype    |   Access privileges   
---------------+----------+----------+-------------+-------------+-----------------------
 gorkinodedb   | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 | 
(1 rows)

postgres=# \connect gorki_node_db
You are now connected to database "gorkinodedb" as user "postgres".

gorki_node_db=# grant all privileges on database "gorki_node_db" to postgres;
GRANT

gorkinodedb=# \q
postgres@naumen:~$
```

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
