### PR TITLE
Fix hashCode for RhoType

### DIFF
--- a/rholang/src/main/scala/io/rhonix/rholang/RhoType.scala
+++ b/rholang/src/main/scala/io/rhonix/rholang/RhoType.scala
@@ -4,6 +4,7 @@ import cats.Eval
 import cats.syntax.all.*
 import io.rhonix.rholang.parmanager.Manager.*
 import sdk.syntax.all.*
+import scala.util.hashing.MurmurHash3
 
 /** Base trait for Rholang elements in the Reducer */
 sealed trait RhoTypeN {
@@ -33,7 +34,9 @@ sealed trait RhoTypeN {
     case _           => false
   }
 
-  override def hashCode(): Int = this.rhoHash.value.hashCode()
+  // Have to hash bytes since this.rhoHash.value.hasCode is different for two copies of the same array
+  private lazy val hCode       = MurmurHash3.arrayHash(this.rhoHash.value)
+  override def hashCode(): Int = hCode
 }
 
 /** Rholang element that can be processed in parallel, together with other elements */

--- a/rholang/src/main/scala/io/rhonix/rholang/RhoType.scala
+++ b/rholang/src/main/scala/io/rhonix/rholang/RhoType.scala
@@ -34,7 +34,8 @@ sealed trait RhoTypeN {
     case _           => false
   }
 
-  // Have to hash bytes since this.rhoHash.value.hasCode is different for two copies of the same array
+  // Have to hash bytes since this.rhoHash.value.hashCode is different for two copies of the same array
+  // TODO Maybe this.rhoHash.value.toList.hashCode is more effective
   private lazy val hCode       = MurmurHash3.arrayHash(this.rhoHash.value)
   override def hashCode(): Int = hCode
 }


### PR DESCRIPTION
## Overview

This PR fixes a bug in hashCode calculation for RhoType class.

Current implementation returns different hash codes for equal instances, because uses hash code of array of bytes, which is derived from memory address not content. This makes all sorts of problems, e.g. `distinct` on list of RhoType does not work.

The change is to use murmur3 to compute the hash, private lazy val is created to cache it. 

### Notes

<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

### Please make sure that this PR:

- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
